### PR TITLE
Use temporary redirect rather than perminant

### DIFF
--- a/templates/nginx.conf.sigil
+++ b/templates/nginx.conf.sigil
@@ -9,7 +9,7 @@ server {
   listen      {{ $listen_port }};
   server_name {{ $.DOMAIN }};
   access_log  off;
-  return 301  $scheme://{{ $.DEST_DOMAIN }}$request_uri;
+  return 302  $scheme://{{ $.DEST_DOMAIN }}$request_uri;
 }
 {{ else if eq $scheme "https"}}
 server {
@@ -21,6 +21,6 @@ server {
   ssl_certificate     {{ $.APP_SSL_PATH }}/server.crt;
   ssl_certificate_key {{ $.APP_SSL_PATH }}/server.key;
 
-  return 301  $scheme://{{ $.DEST_DOMAIN }}$request_uri;
+  return 302  $scheme://{{ $.DEST_DOMAIN }}$request_uri;
 }
 {{ end }}{{ end }}


### PR DESCRIPTION
Temporarily fixes #14. Documented in #13.

Until more time can be spent making response codes dynamic, change to `302`. 

Temporary redirection will still create _roughly_ the same result to the client, but makes debugging / testing redirect rules much easier.