### PR TITLE
Fix deprecation warning in Dokku 0.20.x

### DIFF
--- a/nginx-pre-reload
+++ b/nginx-pre-reload
@@ -19,7 +19,7 @@ redirect_nginx_pre_load_trigger() {
   local REDIRECT_FILE="$APP_ROOT/REDIRECTS"
   [[ ! -s "$REDIRECT_FILE" ]] && exit 0
 
-  [[ "$(get_app_proxy_type "$APP")" == "nginx" ]] || exit 0
+  [[ "$(plugn trigger proxy-type "$APP")" == "nginx" ]] || exit 0
 
   local NGINX_CONF="$APP_ROOT/nginx.conf"
   local NGINX_TEMPLATE="$(dirname "$0")/templates/nginx.conf.sigil"


### PR DESCRIPTION
This simple PR should fix the deprecation warning that can be seen when using this plugin with Dokku 0.20.x: `! Deprecated: plugn#proxy-type`.

I was not able to run the test suite, I’m sorry, but I was able to experimentally verify that the proposed change seems to work on my server.