### PR TITLE
Remove unnecessary source

### DIFF
--- a/nginx-pre-reload
+++ b/nginx-pre-reload
@@ -4,7 +4,6 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/certs/functions"
 source "$PLUGIN_AVAILABLE_PATH/config/functions"
-source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_AVAILABLE_PATH/nginx-vhosts/functions"
 
 # shellcheck disable=SC2155


### PR DESCRIPTION
The function was already changed to the plugin trigger, so the source call isn't necessary.

Closes #32